### PR TITLE
Sync with foreman

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -38,6 +38,14 @@ Gemfile:
       - 'ruby_18'
       groups:
       - 'development'
+  - gem: json_pure
+    version: '~> 1.0'
+    options:
+      platforms:
+      - 'ruby_18'
+      - 'ruby_19'
+      groups:
+      - 'test'
   - gem: metadata-json-lint
 .puppet-lint.rc:
   default_disabled_lint_checks:

--- a/moduleroot/.gitignore
+++ b/moduleroot/.gitignore
@@ -1,5 +1,5 @@
 # This file is managed centrally by modulesync
-#   https://github.com/theforeman/foreman-installer-modulesync
+#   https://github.com/Katello/foreman-installer-modulesync
 
 ## MAC OS
 .DS_Store
@@ -34,6 +34,9 @@ spec/fixtures/
 ## Puppet module
 pkg/
 coverage/
+
+## InteliJ / RubyMine
+.idea
 <% if ! @configs['paths'].nil? -%>
 
 # Module-specific paths

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -1,5 +1,5 @@
 # This file is managed centrally by modulesync
-#   https://github.com/katello/foreman-installer-modulesync
+#   https://github.com/Katello/foreman-installer-modulesync
 
 source 'https://rubygems.org'
 
@@ -12,7 +12,7 @@ if RUBY_VERSION.start_with? '1.8'
 else
   gem 'rake'
   gem 'rspec', '~> 3.0'
-  gem 'rspec-puppet-facts'
+  gem 'rspec-puppet-facts', '>= 1.5'
 end
 <% (@configs['required'] + (@configs['extra'] || [])).each do |gem| -%>
 gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %><%= ", #{gem['options'].inspect}" if gem['options'] %>

--- a/moduleroot/Rakefile
+++ b/moduleroot/Rakefile
@@ -1,5 +1,5 @@
 # This file is managed centrally by modulesync
-#   https://github.com/theforeman/foreman-installer-modulesync
+#   https://github.com/Katello/foreman-installer-modulesync
 
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'

--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 # This file is managed centrally by modulesync
-#   https://github.com/katello/foreman-installer-modulesync
+#   https://github.com/Katello/foreman-installer-modulesync
 
 require 'puppetlabs_spec_helper/module_spec_helper'
 <% (@configs['requires'] || []).each do |r| -%>

--- a/sync_with_foreman.sh
+++ b/sync_with_foreman.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+git clone https://github.com/theforeman/foreman-installer-modulesync.git
+rsync -a --progress --exclude=moduleroot/.travis.yml --exclude=moduleroot/CONTRIBUTING.md --exclude=managed_modules.yml --exclude modulesync.yml foreman-installer-modulesync/* .
+
+rm -rf foreman-installer-modulesync
+
+# Foreman still supports 2.7, we don't
+sed -i -e 's/>= 2.7/~> 3.5/g' moduleroot/Gemfile
+
+# Update URL's to our fork
+find ./moduleroot -type f -exec sed -i -e 's?https://github.com/theforeman/foreman-installer-modulesync?https://github.com/Katello/foreman-installer-modulesync?g' {} \;
+
+


### PR DESCRIPTION
We'll need to pin json_pure like foreman as it dropped < 2.0 support.

This also adds a little script to make it easier to stay in sync with their modulesync.  It can't be 1-1 because of URL's and different testing matrices.
