### PR TITLE
Reflect that puppet 3 default for env path is blank

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -14,7 +14,7 @@ add_custom_fact :concat_basedir, '/tmp'             # puppetlabs-concat
 add_custom_fact :mongodb_version, '2.4.14'          # puppetlabs-mongodb
 add_custom_fact :root_home, '/root'                 # puppetlabs-stdlib
 add_custom_fact :puppetversion, Puppet.version      # Facter, but excluded from rspec-puppet-facts
-add_custom_fact :puppet_environmentpath, Gem::Version.new(Puppet.version) >= Gem::Version.new('4.0') ? '/etc/puppetlabs/code/environments' : '/etc/puppet/environments' # puppetlabs-stdlib
+add_custom_fact :puppet_environmentpath, Gem::Version.new(Puppet.version) >= Gem::Version.new('4.0') ? '/etc/puppetlabs/code/environments' : '' # puppetlabs-stdlib
 
 # Workaround for no method in rspec-puppet to pass undef through :params
 class Undef


### PR DESCRIPTION
On puppet 3, the env path is blank on an unconfigured box, which caused problems w/ the pulp smart proxy plugin.  We should ensure the fact value reflects what occurs in reality (puppet-foreman_proxy is being fixed in https://github.com/theforeman/puppet-foreman_proxy/pull/303).
- [x] https://github.com/Katello/puppet-candlepin/pull/53
- [x] https://github.com/Katello/puppet-capsule/issues/102
- [x] https://github.com/Katello/puppet-certs/issues/109
- [x] https://github.com/Katello/puppet-common/issues/15
- [x] https://github.com/Katello/puppet-crane/issues/14
- [x] https://github.com/Katello/puppet-katello/issues/147
- [x] https://github.com/Katello/puppet-katello_devel/issues/90
- [x] https://github.com/Katello/puppet-qpid/issues/43
- [x] https://github.com/Katello/puppet-service_wait/issues/18
