### PR TITLE
Sync with Foreman - drop 1.8.7

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -1,8 +1,13 @@
 ---
 Gemfile:
   required:
+  - gem: rake
+  - gem: rspec
+    version: '~> 3.0'
   - gem: rspec-puppet
     version: '~> 2.3'
+  - gem: rspec-puppet-facts
+    version: '>= 1.7'
   - gem: puppetlabs_spec_helper
     version: '>= 0.8.0'
   - gem: puppet-lint
@@ -24,25 +29,10 @@ Gemfile:
     options:
       groups:
       - 'development'
-  - gem: rest-client
-    version: '< 1.7'
-    options:
-      platforms:
-      - 'ruby_18'
-      groups:
-      - 'development'
-  - gem: mime-types
-    version: '~> 1.0'
-    options:
-      platforms:
-      - 'ruby_18'
-      groups:
-      - 'development'
   - gem: json
     version: '~> 1.0'
     options:
       platforms:
-      - 'ruby_18'
       - 'ruby_19'
       groups:
       - 'test'
@@ -50,13 +40,10 @@ Gemfile:
     version: '~> 1.0'
     options:
       platforms:
-      - 'ruby_18'
       - 'ruby_19'
       groups:
       - 'test'
   - gem: metadata-json-lint
-  - gem: rspec-puppet-facts
-    version: '>= 1.7'
 .puppet-lint.rc:
   default_disabled_lint_checks:
   - '140chars'

--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -6,26 +6,21 @@ rvm:
   - 2.0.0
   - 2.1.5
 env:
-  - PUPPET_VERSION=3.5 ONLY_OS=redhat-6-x86_64,centos-6-x86_64,redhat-7-x86_64,centos-7-x86_64
-  - PUPPET_VERSION=3.5 FUTURE_PARSER=yes ONLY_OS=redhat-6-x86_64,centos-6-x86_64,redhat-7-x86_64,centos-7-x86_64
-  - PUPPET_VERSION=4.0 ONLY_OS=redhat-6-x86_64,centos-6-x86_64,redhat-7-x86_64,centos-7-x86_64
+  - PUPPET_VERSION=3.5 ONLY_OS=redhat-7-x86_64,centos-7-x86_64
+  - PUPPET_VERSION=3.5 FUTURE_PARSER=yes ONLY_OS=redhat-7-x86_64,centos-7-x86_64
+  - PUPPET_VERSION=4.0 ONLY_OS=redhat-7-x86_64,centos-7-x86_64
 matrix:
   fast_finish: true
   exclude:
     # No support for Ruby 1.9.3 on Puppet 4.x
     - rvm: 1.9.3
-      env: PUPPET_VERSION=4.0 ONLY_OS=redhat-6-x86_64,centos-6-x86_64,redhat-7-x86_64,centos-7-x86_64
+      env: PUPPET_VERSION=4.0 ONLY_OS=redhat-7-x86_64,centos-7-x86_64
   include:
-    # Only platforms left to support ruby 1.8.7
-    - rvm: 1.8.7
-      env: PUPPET_VERSION=3.5 ONLY_OS=redhat-6-x86_64,centos-6-x86_64,redhat-7-x86_64,centos-7-x86_64
-    - rvm: 1.8.7
-      env: PUPPET_VERSION=3.5 FUTURE_PARSER=yes
     # Only Puppet 4.x supports Ruby 2.2. Also limit the OS set we test Ruby 2.2 with.
     - rvm: 2.2.3
-      env: PUPPET_VERSION=4.0 ONLY_OS=redhat-6-x86_64,centos-6-x86_64,redhat-7-x86_64,centos-7-x86_64
+      env: PUPPET_VERSION=4.0 ONLY_OS=redhat-7-x86_64,centos-7-x86_64
     # Only Puppet >= 4.4 supports Ruby 2.3. Also limit the OS set we test Ruby 2.3 with.
     - rvm: 2.3.0
-      env: PUPPET_VERSION=4.4 ONLY_OS=redhat-6-x86_64,centos-6-x86_64,redhat-7-x86_64,centos-7-x86_64
+      env: PUPPET_VERSION=4.4 ONLY_OS=redhat-7-x86_64,centos-7-x86_64
 bundler_args: --without development
 sudo: false

--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -5,13 +5,6 @@ source 'https://rubygems.org'
 
 gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 3.5'
 
-if RUBY_VERSION.start_with? '1.8'
-  gem 'rake', '< 11'
-  gem 'rspec', '>= 3', '< 3.2'
-else
-  gem 'rake'
-  gem 'rspec', '~> 3.0'
-end
 <% (@configs['required'] + (@configs['extra'] || [])).each do |gem| -%>
 gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %><%= ", #{gem['options'].inspect}" if gem['options'] %>
 <% end -%>

--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -39,6 +39,14 @@ def exclude_test_os
   end
 end
 
+# Use the above environment variables to limit the platforms under test
+def on_os_under_test
+  on_supported_os.reject do |os, facts|
+    (only_test_os() && !only_test_os.include?(os)) ||
+      (exclude_test_os() && exclude_test_os.include?(os))
+  end
+end
+
 def get_content(subject, title)
   content = subject.resource('file', title).send(:parameters)[:content]
   content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }


### PR DESCRIPTION
Foreman has dropped 1.8.7 support, and we should do as el6 is dead for Katello 3.3. 

The main driver of this is the nightly katello and capsule modules are no longer compatible with the versions in Foreman git, as they've bumped majors and all our modules are locked to older versions of Foreman's modules.  This is causing problems, with for example https://github.com/Katello/katello-installer/pull/411
- [x] https://github.com/Katello/puppet-capsule/pull/103
- [x] https://github.com/Katello/puppet-service_wait/pull/19
- [x] https://github.com/Katello/puppet-katello/pull/149
- [x] https://github.com/Katello/puppet-candlepin/pull/55
- [x] https://github.com/Katello/puppet-qpid/pull/44
- [x] https://github.com/Katello/puppet-crane/pull/15
- [x] https://github.com/Katello/puppet-common/pull/16
- [x] https://github.com/Katello/puppet-certs/pull/110
- [x] https://github.com/Katello/puppet-pulp/pull/169
- [x] https://github.com/Katello/puppet-katello_devel/pull/91
