### PR TITLE
Allow puppet 4 when PUPPET_VERSION is unset

### DIFF
--- a/moduleroot/Gemfile
+++ b/moduleroot/Gemfile
@@ -3,7 +3,7 @@
 
 source 'https://rubygems.org'
 
-gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '~> 3.5'
+gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '>= 3.5'
 
 <% (@configs['required'] + (@configs['extra'] || [])).each do |gem| -%>
 gem '<%= gem['gem'] %>'<%= ", '#{gem['version']}'" if gem['version'] %><%= ", #{gem['options'].inspect}" if gem['options'] %>


### PR DESCRIPTION
Since ~> 3.5 doesn't allow 4.x, it forces me to always set
PUPPET_VERSION to use 4.x. By using >= it should also use 4.x.