### PR TITLE
Enable strict indent puppet lint check

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -23,6 +23,7 @@ Gemfile:
   - gem: puppet-lint-file_ensure-check
   - gem: puppet-lint-param-docs
     version: '>= 1.3.0'
+  - gem: puppet-lint-strict_indent-check
   - gem: simplecov
   - gem: puppet-blacksmith
     version: '>= 3.1.0'


### PR DESCRIPTION
I'd guess we probably have some failures for this in our modules, haven't checked yet.  

@chris1984 pointed out we weren't checking for any indentation with lint.
