### PR TITLE
Add infrastructure for acceptance testing

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -43,13 +43,25 @@ Gemfile:
       - 'ruby_19'
       groups:
       - 'test'
+  - gem: 'beaker-rspec'
+    options:
+      groups:
+        - 'system_tests'
+  - gem: 'beaker-puppet_install_helper'
+    options:
+      groups:
+        - 'system_tests'
   - gem: metadata-json-lint
   - gem: kafo_module_lint
 .puppet-lint.rc:
   default_disabled_lint_checks:
   - '140chars'
   - 'class_inherits_from_params_class'
+.travis.yml:
+  beaker_sets: []
 spec/spec_helper.rb:
   requires: []
+spec/spec_helper_acceptance.rb:
+  modules: ['puppetlabs-stdlib']
 Rakefile:
   param_docs_pattern: []

--- a/moduleroot/.travis.yml
+++ b/moduleroot/.travis.yml
@@ -19,5 +19,16 @@ matrix:
     # Only Puppet >= 4.4 supports Ruby 2.3. Also limit the OS set we test Ruby 2.3 with.
     - rvm: 2.3.0
       env: PUPPET_VERSION=4.4 ONLY_OS=redhat-7-x86_64,centos-7-x86_64
-bundler_args: --without development
+<% if !@configs['beaker_sets'].empty? -%>
+    # Acceptance tests
+<% @configs['beaker_sets'].each do |set| -%>
+    - rvm: 2.3.1
+      dist: trusty
+      env: PUPPET_INSTALL_TYPE=agent BEAKER_debug=true BEAKER_set=<%= set %>
+      script: bundle exec rake beaker
+      services: docker
+      bundler_args: --without development
+<% end -%>
+<% end -%>
+bundler_args: --without system_tests development
 sudo: false

--- a/moduleroot/spec/acceptance/nodesets/docker/centos-6.yml
+++ b/moduleroot/spec/acceptance/nodesets/docker/centos-6.yml
@@ -1,0 +1,20 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/Katello/foreman-installer-modulesync
+HOSTS:
+  centos-6-x64:
+    platform: el-6-x86_64
+    hypervisor: docker
+    image: centos:6
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'rm -rf /var/run/network/*'
+      - 'yum install -y crontabs initscripts iproute openssl sysvinit-tools tar wget which'
+      - 'rm /etc/init/tty.conf'
+CONFIG:
+  trace_limit: 200
+  masterless: true
+...
+# vim: syntax=yaml

--- a/moduleroot/spec/acceptance/nodesets/docker/centos-7.yml
+++ b/moduleroot/spec/acceptance/nodesets/docker/centos-7.yml
@@ -1,0 +1,19 @@
+---
+# This file is managed via modulesync
+# https://github.com/voxpupuli/modulesync
+# https://github.com/Katello/foreman-installer-modulesync
+HOSTS:
+  centos-7-x64:
+    platform: el-7-x86_64
+    hypervisor: docker
+    image: centos:7
+    docker_preserve_image: true
+    docker_cmd: '["/usr/sbin/init"]'
+    docker_image_commands:
+      - 'yum install -y crontabs initscripts iproute openssl sysvinit-tools tar wget which ss'
+      - 'systemctl mask getty@tty1.service'
+CONFIG:
+  trace_limit: 200
+  masterless: true
+...
+# vim: syntax=yaml

--- a/moduleroot/spec/spec_helper_acceptance.rb
+++ b/moduleroot/spec/spec_helper_acceptance.rb
@@ -1,0 +1,42 @@
+require 'beaker-rspec/spec_helper'
+require 'beaker-rspec/helpers/serverspec'
+require 'beaker/puppet_install_helper'
+
+run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
+
+RSpec.configure do |c|
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module and dependencies
+    puppet_module_install(:source => proj_root, :module_name => '<%= @configs[:puppet_module].split('-').last %>')
+    hosts.each do |host|
+      <%= @configs['modules'].inspect %>.each do |mod|
+        on host, puppet('module', 'install', mod), { :acceptable_exit_codes => [0] }
+      end
+
+      if fact_on(host, 'osfamily') == 'RedHat'
+        # don't delete downloaded rpm for use with BEAKER_provision=no +
+        # BEAKER_destroy=no
+        on host, 'sed -i "s/keepcache=.*/keepcache=1/" /etc/yum.conf'
+        # refresh check if cache needs refresh on next yum command
+        on host, 'yum clean expire-cache'
+      end
+    end
+  end
+end
+
+shared_examples 'a idempotent resource' do
+  it 'applies with no errors' do
+    apply_manifest(pp, catch_failures: true)
+  end
+
+  it 'applies a second time without changes' do
+    apply_manifest(pp, catch_changes: true)
+  end
+end


### PR DESCRIPTION
* [x] https://github.com/Katello/puppet-candlepin/pull/66
* [x] https://github.com/Katello/puppet-certs/pull/146
* [x] https://github.com/Katello/puppet-common/pull/19
* [x] https://github.com/Katello/puppet-crane/pull/19
* [x] https://github.com/Katello/puppet-foreman_proxy_content/pull/116
* [x] https://github.com/Katello/puppet-katello/pull/178
* [x] https://github.com/Katello/puppet-katello_devel/pull/102
* [x] https://github.com/Katello/puppet-pulp/pull/213
* [x] https://github.com/Katello/puppet-qpid/pull/54
* [x] https://github.com/Katello/puppet-service_wait/pull/22