### PR TITLE
Disable arrow_on_right_operand_line puppet-lint check

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -57,6 +57,7 @@ Gemfile:
 .puppet-lint.rc:
   default_disabled_lint_checks:
   - '140chars'
+  - 'arrow_on_right_operand_line'
   - 'class_inherits_from_params_class'
 .travis.yml:
   beaker_sets: []


### PR DESCRIPTION
- [x] https://github.com/Katello/puppet-candlepin/pull/71
- [x] https://github.com/Katello/puppet-certs/pull/151
- [x] https://github.com/Katello/puppet-common/pull/20
- [x] https://github.com/Katello/puppet-foreman_proxy_content/pull/117
- [x] https://github.com/Katello/puppet-katello/pull/183
- [x] https://github.com/Katello/puppet-katello_devel/pull/103
- [x] https://github.com/Katello/puppet-pulp/pull/218
- [x] https://github.com/Katello/puppet-qpid/pull/57
- [x] https://github.com/Katello/puppet-service_wait/pull/23