### PR TITLE
Better error reporting in spec helper functions

### DIFF
--- a/moduleroot/spec/spec_helper.rb
+++ b/moduleroot/spec/spec_helper.rb
@@ -48,21 +48,24 @@ def on_os_under_test
 end
 
 def get_content(subject, title)
+  is_expected.to contain_file(title)
   content = subject.resource('file', title).send(:parameters)[:content]
   content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }
 end
 
 def verify_exact_contents(subject, title, expected_lines)
-  expect(get_content(subject, title)).to eq(expected_lines)
+  expect(get_content(subject, title)).to match_array(expected_lines)
 end
 
 def verify_concat_fragment_contents(subject, title, expected_lines)
+  is_expected.to contain_concat__fragment(title)
   content = subject.resource('concat::fragment', title).send(:parameters)[:content]
-  expect(content.split("\n") & expected_lines).to eq(expected_lines)
+  expect(content.split("\n") & expected_lines).to match_array(expected_lines)
 end
 
 def verify_concat_fragment_exact_contents(subject, title, expected_lines)
+  is_expected.to contain_concat__fragment(title)
   content = subject.resource('concat::fragment', title).send(:parameters)[:content]
-    expect(content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }).to eq(expected_lines)
+  expect(content.split(/\n/).reject { |line| line =~ /(^#|^$|^\s+#)/ }).to match_array(expected_lines)
 end
 <%= "\n" + @configs['extra_code'] if @configs['extra_code'] -%>


### PR DESCRIPTION
Copied from foreman-installer-modulesync. These versions show a much
clearer error message when an expectation is not met.