### PR TITLE
Use FQDN hostnames

### DIFF
--- a/moduleroot/spec/acceptance/nodesets/docker/centos-6.yml
+++ b/moduleroot/spec/acceptance/nodesets/docker/centos-6.yml
@@ -3,7 +3,7 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/Katello/foreman-installer-modulesync
 HOSTS:
-  centos-6-x64:
+  centos-6-x64.example.com:
     platform: el-6-x86_64
     hypervisor: docker
     image: centos:6

--- a/moduleroot/spec/acceptance/nodesets/docker/centos-7.yml
+++ b/moduleroot/spec/acceptance/nodesets/docker/centos-7.yml
@@ -3,7 +3,7 @@
 # https://github.com/voxpupuli/modulesync
 # https://github.com/Katello/foreman-installer-modulesync
 HOSTS:
-  centos-7-x64:
+  centos-7-x64.example.com:
     platform: el-7-x86_64
     hypervisor: docker
     image: centos:7


### PR DESCRIPTION
By using short names you will end up with the following hosts file:

    192.168.122.100 centos-7-x64
    127.0.0.1 localhost
    192.168.122.100 centos-7-x64.example.com

The result is that facter fqdn returns centos-7-x64.example.com where
hostname -f returns centos-7-x64. This breaks some scripts with pulp.